### PR TITLE
post interest in group

### DIFF
--- a/src/__tests__/pages/__snapshots__/questionnairePage.test.tsx.snap
+++ b/src/__tests__/pages/__snapshots__/questionnairePage.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`questionnairePage should render correctly 1`] = `
 <div
-  className="f1ipot1o"
+  className="f1uq22z4"
 >
   <h1>
     Idrettsvalgomat
@@ -154,7 +154,7 @@ exports[`questionnairePage should render correctly 1`] = `
       </div>
     </div>
     <button
-      className="fcns19z btn btn-custom"
+      className="f1sav644 btn btn-warning"
       disabled={false}
       type="submit"
     >

--- a/src/__tests__/pages/__snapshots__/resultPage.test.tsx.snap
+++ b/src/__tests__/pages/__snapshots__/resultPage.test.tsx.snap
@@ -69,7 +69,7 @@ exports[`resultPage snapshot tests should render correctly 1`] = `
   </a>
   <br />
   <a
-    className="f1n6sq50 btn btn-primary"
+    className="f1crc5ka btn btn-warning"
     href="/questionnaire"
     onClick={[Function]}
     onKeyDown={[Function]}

--- a/src/__tests__/redux/interestActions.test.ts
+++ b/src/__tests__/redux/interestActions.test.ts
@@ -1,0 +1,30 @@
+import React from 'react';
+import {
+    setSessionIDActionCreator,
+    addInterestActionCreator,
+    SET_SESSIONID,
+    ADD_INTEREST,
+} from '../../store/pages/interest/interestActions';
+
+describe('Interest Actions', () => {
+    test('Should be of type SET_SESSIONID', () => {
+        expect(setSessionIDActionCreator().type).toStrictEqual(SET_SESSIONID);
+    });
+
+    test('Should generate a string sessionID', () => {
+        expect(typeof setSessionIDActionCreator().payload).toBe('string');
+    });
+
+    test('Should generate a 16 charachter sessionID', () => {
+        expect(setSessionIDActionCreator().payload.length).toBe(16);
+    });
+
+    test('Should create addInterest action', () => {
+        const data = '1';
+        const expected = {
+            type: ADD_INTEREST,
+            payload: data,
+        };
+        expect(addInterestActionCreator(data)).toStrictEqual(expected);
+    });
+});

--- a/src/__tests__/redux/interestReducer.test.ts
+++ b/src/__tests__/redux/interestReducer.test.ts
@@ -1,0 +1,49 @@
+import React from 'react';
+import { interestInitialState, interestReducer } from '../../store/pages/interest/interestReducer';
+import { SET_SESSIONID, ADD_INTEREST } from '../../store/pages/interest/interestActions';
+
+describe('Interest reducer', () => {
+    it('Should return the initial state', () => {
+        const initialState = interestInitialState;
+        expect(interestReducer(undefined, {})).toEqual(initialState);
+    });
+
+    it('Should handle SET_SESSIONID', () => {
+        const data = 'thisIsASessionID';
+
+        expect(
+            interestReducer(undefined, {
+                type: SET_SESSIONID,
+                payload: data,
+            }),
+        ).toEqual({ sessionID: data, interests: [] });
+    });
+
+    it('Should handle ADD_INTEREST', () => {
+        const data = '1';
+
+        expect(
+            interestReducer(undefined, {
+                type: ADD_INTEREST,
+                payload: data,
+            }),
+        ).toEqual({ sessionID: null, interests: [data] });
+    });
+
+    it('Should handle ADD_INTEREST with initialState', () => {
+        const initialState1 = 'sessionID';
+        const initialState2 = ['1', '2'];
+
+        const data = ['1', '2', '3'];
+
+        expect(
+            interestReducer(
+                { sessionID: initialState1, interests: initialState2 },
+                {
+                    type: ADD_INTEREST,
+                    payload: '3',
+                },
+            ),
+        ).toEqual({ sessionID: initialState1, interests: data });
+    });
+});

--- a/src/pages/groupPage.tsx
+++ b/src/pages/groupPage.tsx
@@ -1,12 +1,11 @@
 import React, { useEffect } from 'react';
 import { Spinner } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import SearchBar from '../components/SearchBar/searchBar';
-import SearchIcon from '../components/SearchBar/searchIcon';
 import TeamCard from '../components/TeamCard/teamCard';
 import { GROUP, TEAM } from '../constants';
-import { fetchDataThunk, fetchDetailThunk } from '../services/api';
+import { fetchDataThunk, fetchDetailThunk, handleInterestThunk } from '../services/api';
 import { combinedStateInterface } from '../store/store';
 import GroupInfo from '../components/GroupInfo/groupInfo';
 import { urlBuilderFilterData } from '../services/urlBuilders';
@@ -23,7 +22,6 @@ const GroupPage = (): JSX.Element => {
     const urlParams = useParams<urlParams>();
     const dispatch = useDispatch();
     const reduxState = useSelector((state: combinedStateInterface) => state);
-    const location = useLocation();
 
     useEffect(() => {
         if (
@@ -35,6 +33,11 @@ const GroupPage = (): JSX.Element => {
                 fetchDataThunk(TEAM, urlBuilderFilterData(TEAM, [{ cardType: 'group', id_or_name: urlParams.id }])),
             );
             dispatch(fetchDetailThunk(GROUP, urlParams.id));
+            console.log('Should enter right here: ');
+            if (!reduxState.interest.interests.includes(urlParams.id) && reduxState.interest.sessionID) {
+                console.log('Now it has entered: ');
+                dispatch(handleInterestThunk(urlParams.id, reduxState.interest.sessionID));
+            }
         }
     });
 

--- a/src/pages/groupPage.tsx
+++ b/src/pages/groupPage.tsx
@@ -33,9 +33,7 @@ const GroupPage = (): JSX.Element => {
                 fetchDataThunk(TEAM, urlBuilderFilterData(TEAM, [{ cardType: 'group', id_or_name: urlParams.id }])),
             );
             dispatch(fetchDetailThunk(GROUP, urlParams.id));
-            console.log('Should enter right here: ');
             if (!reduxState.interest.interests.includes(urlParams.id) && reduxState.interest.sessionID) {
-                console.log('Now it has entered: ');
                 dispatch(handleInterestThunk(urlParams.id, reduxState.interest.sessionID));
             }
         }

--- a/src/pages/groupPage.tsx
+++ b/src/pages/groupPage.tsx
@@ -33,7 +33,13 @@ const GroupPage = (): JSX.Element => {
                 fetchDataThunk(TEAM, urlBuilderFilterData(TEAM, [{ cardType: 'group', id_or_name: urlParams.id }])),
             );
             dispatch(fetchDetailThunk(GROUP, urlParams.id));
-            if (!reduxState.interest.interests.includes(urlParams.id) && reduxState.interest.sessionID) {
+            if (
+                !reduxState.interest.interests.includes(urlParams.id) &&
+                reduxState.interest.sessionID &&
+                !reduxState.thunk.post_in_progress &&
+                reduxState.thunk.post_failed_count < 3 &&
+                !reduxState.thunk.post_success
+            ) {
                 dispatch(handleInterestThunk(urlParams.id, reduxState.interest.sessionID));
             }
         }

--- a/src/pages/landingPage.tsx
+++ b/src/pages/landingPage.tsx
@@ -1,9 +1,21 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Link } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { combinedStateInterface } from '../store/store';
+import { setSessionIDActionCreator } from '../store/pages/interest/interestActions';
 import { style, classes } from 'typestyle';
 import colors from '../styles/colors';
 
-const LandingPage = () => {
+const LandingPage = (): JSX.Element => {
+    const dispatch = useDispatch();
+    const reduxState = useSelector((state: combinedStateInterface) => state);
+
+    useEffect(() => {
+        if (!reduxState.interest.sessionID) {
+            dispatch(setSessionIDActionCreator());
+        }
+    }, []);
+
     return (
         <div className={frontPage}>
             <div className={wrapper}>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -4,6 +4,7 @@ import { cardType, CITY, CLUB, GROUP, REGION, SEARCH, SPORT, TEAM } from '../con
 import { setCitiesActionCreator } from '../store/pages/city/cityActions';
 import { setClubsActionCreator, setClubsActionDetailCreator } from '../store/pages/club/clubActions';
 import { setGroupsActionCreator, setGroupsActionDetailCreator } from '../store/pages/group/groupActions';
+import { addInterestActionCreator } from '../store/pages/interest/interestActions';
 import { setRegionsActionCreator } from '../store/pages/region/regionActions';
 import { setSportsActionCreator, setSportsActionDetailCreator } from '../store/pages/sport/sportActions';
 import { setTeamsActionCreator, setTeamsActionDetailCreator } from '../store/pages/team/teamActions';
@@ -22,6 +23,7 @@ import {
     urlBuilderFetchDetail,
     urlBuilderGetQuestions,
     urlBuilderPostQuestions,
+    urlBuilderPostInterest,
 } from './urlBuilders';
 import { setSearchActionCreator } from '../store/pages/search/searchActions';
 import {
@@ -72,7 +74,7 @@ export const checkForErrorCodes = (result: any): boolean => {
 
 export const fetchDataThunk = (
     dataType: cardType,
-    url: string = '',
+    url = '',
 ): ThunkAction<void, combinedStateInterface, unknown, Action<string>> => async (dispatch) => {
     let asyncResp;
     dispatch(fetchInProgressActionCreator());
@@ -199,5 +201,21 @@ export const handleQuestionsThunk = (
             dispatch(postSuccessActionCreator());
             dispatch(setRecommendatationsActionCreator(asyncResp.recommendation));
         }
+    }
+};
+
+export const handleInterestThunk = (
+    groupID: string,
+    sessionID: string,
+): ThunkAction<void, combinedStateInterface, unknown, Action<string>> => async (dispatch) => {
+    dispatch(postInProgressActionCreator());
+    const asyncResp = await postData(urlBuilderPostInterest(), { session_id: sessionID, group: groupID });
+
+    if (asyncResp === 'Something went wrong' || asyncResp === 'Connection error') {
+        dispatch(postFailedActionCreator());
+        return;
+    } else {
+        dispatch(postSuccessActionCreator());
+        dispatch(addInterestActionCreator(groupID));
     }
 };

--- a/src/services/urlBuilders.ts
+++ b/src/services/urlBuilders.ts
@@ -48,3 +48,7 @@ export const urlBuilderGetQuestions = (): string => {
 export const urlBuilderPostQuestions = (): string => {
     return BASE_URL + '/questionnaire/';
 };
+
+export const urlBuilderPostInterest = (): string => {
+    return BASE_URL + '/interest/';
+};

--- a/src/store/pages/interest/interestActions.ts
+++ b/src/store/pages/interest/interestActions.ts
@@ -1,0 +1,30 @@
+export const SET_SESSIONID = 'SET_SESSIONID';
+export const ADD_INTEREST = 'ADD_INTEREST';
+
+interface setSessionIDAction {
+    type: typeof SET_SESSIONID;
+    payload: string;
+}
+
+interface addInterestAction {
+    type: typeof ADD_INTEREST;
+    payload: string;
+}
+
+export type interestActionTypes = setSessionIDAction | addInterestAction;
+
+export const setSessionIDActionCreator = (): interestActionTypes => {
+    let generatedID;
+    for (generatedID = ''; generatedID.length < 16; ) generatedID += Math.random().toString(36).substr(2, 1);
+    return {
+        type: SET_SESSIONID,
+        payload: generatedID,
+    };
+};
+
+export const addInterestActionCreator = (data: string): interestActionTypes => {
+    return {
+        type: ADD_INTEREST,
+        payload: data,
+    };
+};

--- a/src/store/pages/interest/interestReducer.ts
+++ b/src/store/pages/interest/interestReducer.ts
@@ -1,0 +1,31 @@
+import { SET_SESSIONID, ADD_INTEREST, interestActionTypes } from './interestActions';
+
+export interface interestState {
+    sessionID: string | null;
+    interests: string[];
+}
+
+export const interestInitialState: interestState = {
+    sessionID: null,
+    interests: [],
+};
+
+export const interestReducer = (state = interestInitialState, action: interestActionTypes): interestState => {
+    switch (action.type) {
+        case SET_SESSIONID: {
+            return {
+                ...state,
+                sessionID: action.payload,
+            };
+        }
+        case ADD_INTEREST: {
+            return {
+                ...state,
+                interests: [...state.interests, action.payload],
+            };
+        }
+        default: {
+            return state;
+        }
+    }
+};

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -4,6 +4,7 @@ import thunk from 'redux-thunk';
 import { cityInitialState, cityReducer, cityState } from './pages/city/cityReducer';
 import { clubInitialState, clubReducer, clubState } from './pages/club/clubReducer';
 import { groupInitialState, groupReducer, groupState } from './pages/group/groupReducer';
+import { interestInitialState, interestReducer, interestState } from './pages/interest/interestReducer';
 import { regionInitialState, regionReducer, regionState } from './pages/region/regionReducer';
 import { sportInitialState, sportReducer, sportState } from './pages/sport/sportReducer';
 import { teamInitialState, teamReducer, teamState } from './pages/team/teamReducer';
@@ -32,6 +33,7 @@ export interface combinedStateInterface {
     club: clubState;
     team: teamState;
     group: groupState;
+    interest: interestState;
     search_results: searchState;
     thunk: thunkState;
     searchBar: searchBarState;
@@ -46,6 +48,7 @@ export const combinedState = {
     club: clubInitialState,
     team: teamInitialState,
     group: groupInitialState,
+    interest: interestInitialState,
     search_results: searchInitialState,
     thunk: thunkInitialState,
     searchBar: searchBarInitialState,
@@ -61,6 +64,7 @@ const store = createStore(
         club: clubReducer,
         team: teamReducer,
         group: groupReducer,
+        interest: interestReducer,
         search_results: searchReducer,
         thunk: thunkReducer,
         searchBar: searchBarReducer,


### PR DESCRIPTION
SessionID is created and added to redux store when first going to landingPage (front page).
When clicking on a group, a post-request is sent with the stored sessionID and the groupID of the group.
If the request is successful, add the groupID to a list (redux store) with interests that has been created this session.

Currently waiting on a PR-approval on backend that integrates support for the frontend implementation, but it has been tested locally and it works as it's supposed to.